### PR TITLE
Bump hyper version to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 env_logger = "0.3"
 
 [dependencies]
-hyper = "0.9"
+hyper = "0.10"
 log = "0.3"
 serde = "0.9"
 serde_derive = "0.9"


### PR DESCRIPTION
According to the changelog on Hyper non of the breaking changes should
cause issues with this crate.

https://github.com/hyperium/hyper/blob/v0.10.4/CHANGELOG.md#breaking-changes-1