### PR TITLE
Add support for constructing a Jira client from given reqwest client; Add support for changelog; Fix Iter not preserving search options after first request.

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -2,7 +2,7 @@ use url::form_urlencoded;
 use std::collections::HashMap;
 
 /// options availble for search
-#[derive(Default)]
+#[derive(Default, Clone, Debug)]
 pub struct SearchOptions {
     params: HashMap<&'static str, String>,
 }
@@ -23,11 +23,15 @@ impl SearchOptions {
                 .finish())
         }
     }
+
+    pub fn as_builder(&self) -> SearchOptionsBuilder {
+        SearchOptionsBuilder::copy_from(self)
+    }
 }
 
 /// a builder interface for search option
 /// Typically this is initialized with SearchOptions::builder()
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SearchOptionsBuilder {
     params: HashMap<&'static str, String>,
 }
@@ -35,6 +39,10 @@ pub struct SearchOptionsBuilder {
 impl SearchOptionsBuilder {
     pub fn new() -> SearchOptionsBuilder {
         SearchOptionsBuilder { ..Default::default() }
+    }
+
+    fn copy_from(search_options: &SearchOptions) -> SearchOptionsBuilder {
+        SearchOptionsBuilder { params: search_options.params.clone() }
     }
 
     pub fn fields<F>(&mut self, fs: Vec<F>) -> &mut SearchOptionsBuilder

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -37,3 +37,40 @@ impl From<IoError> for Error {
         Error::IO(error)
     }
 }
+
+impl ::std::fmt::Display for Error {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+        use Error::*;
+        match self {
+            &Http(ref e) => writeln!(f, "Http Error: {}", e),
+            &IO(ref e) => writeln!(f, "IO Error: {}", e),
+            &Serde(ref e) => writeln!(f, "Serialization Error: {}", e),
+            &Fault { ref code, ref errors } => writeln!(f, "Jira Client Error ({}):\n{:#?}", code, errors),
+            &Unauthorized => writeln!(f, "Could not connect to Jira: Unauthorized!"),
+        }
+    }
+}
+
+impl ::std::error::Error for Error {
+    fn description(&self) -> &str {
+        use Error::*;
+        match self {
+            &Http(ref e) => e.description(),
+            &IO(ref e) => e.description(),
+            &Serde(ref e) => e.description(),
+            &Fault { .. } => "Jira client error",
+            &Unauthorized => "Unauthorized",
+        }
+    }
+
+    fn cause(&self) -> Option<&::std::error::Error> {
+        use Error::*;
+        match self {
+            &Http(ref e) => Some(e),
+            &IO(ref e) => Some(e),
+            &Serde(ref e) => Some(e),
+            &Fault { .. } => None,
+            &Unauthorized => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,18 @@ impl Jira {
         })
     }
 
+    /// creates a new instance of a jira client using a specified reqwest client
+    pub fn from_client<H>(host: H, credentials: Credentials, client: Client) -> Result<Jira>
+    where
+        H: Into<String>,
+    {
+        Ok(Jira {
+            host: host.into(),
+            credentials,
+            client,
+        })
+    }
+
     /// return transitions interface
     pub fn transitions<K>(&self, key: K) -> Transitions
     where

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -145,6 +145,7 @@ pub struct Changelog {
 #[derive(Deserialize, Debug)]
 pub struct History {
     pub author: User,
+    pub created: String,
     pub items: Vec<HistoryItem>
 }
 

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -19,17 +19,15 @@ pub struct Issue {
     pub self_link: String,
     pub key: String,
     pub id: String,
-    //    pub expand: String,
     pub fields: BTreeMap<String, ::serde_json::Value>,
+    pub changelog: Option<Changelog>,
 }
 
 impl Issue {
     /// resolves a typed field from an issues lists of arbitrary fields
-    pub fn field<'a, F>(&self, name: &str) -> Option<Result<F>>
+    pub fn field<F>(&self, name: &str) -> Option<Result<F>>
     where
         for<'de> F: Deserialize<'de>,
-    //where
-    //    F: Deserialize<'a>,
     {
         self.fields.get(name).map(|value| {
             let decoded = try!(serde_json::value::from_value::<F>(value.clone()));
@@ -139,6 +137,27 @@ impl Issue {
     }
 }
 
+#[derive(Deserialize, Debug)]
+pub struct Changelog {
+    pub histories: Vec<History>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct History {
+    pub author: User,
+    pub items: Vec<HistoryItem>
+}
+
+#[derive(Deserialize, Debug)]
+pub struct HistoryItem {
+    pub field: String,
+    pub from: Option<String>,
+    #[serde(rename = "fromString")]
+    pub from_string: Option<String>,
+    pub to: Option<String>,
+    #[serde(rename = "toString")]
+    pub to_string: Option<String>,
+}
 
 #[derive(Deserialize, Debug)]
 pub struct Project {
@@ -192,12 +211,12 @@ pub struct User {
     pub display_name: String,
     #[serde(rename = "emailAddress")]
     pub email_address: String,
-    pub key: String,
+    pub key: Option<String>,
     pub name: String,
     #[serde(rename = "self")]
     pub self_link: String,
     #[serde(rename = "timeZone")]
-    pub timezone: String,
+    pub timezone: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -18,7 +18,7 @@ pub struct Issue {
     #[serde(rename = "self")]
     pub self_link: String,
     pub key: String,
-    pub id: u64,
+    pub id: String,
     //    pub expand: String,
     pub fields: BTreeMap<String, ::serde_json::Value>,
 }


### PR DESCRIPTION
I've added support for querying changelogs and fixed the `Iterator` implementation for `Iter` so it preserves the search options, which can contain vital information, such as which fields to include and what to expand. I also added a constructor function for creating Jira client with customized reqwest client (I needed that to add a custom CA).

Also, I've changed data types for some fields since they had different types in the Jira version I use (v6.3.12). Feel free to reject those changes. I suppose there should be a mechanism to choose the jira version you want to target...