### PR TITLE
Use agile REST API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ impl Jira {
     where
         D: DeserializeOwned,
     {
-        let url = format!("{}/rest/api/latest{}", self.host, endpoint);
+        let url = format!("{}/rest/agile/latest{}", self.host, endpoint);
         debug!("url -> {:?}", url);
 
         let mut req = self.client.request(method, &url)?;


### PR DESCRIPTION
The current URL doesn't allow to access boards and sprints; the [Jira Agile Server REST API](https://docs.atlassian.com/jira-software/REST/latest) uses the path `/rest/agile/latest`.

This patch update the REST API path to the one in the documentation.