### PR TITLE
Fixed more() method

### DIFF
--- a/src/boards.rs
+++ b/src/boards.rs
@@ -91,7 +91,7 @@ impl<'a> BoardsIter<'a> {
     }
 
     fn more(&self) -> bool {
-        self.results.is_last
+        !self.results.is_last
     }
 }
 

--- a/src/sprints.rs
+++ b/src/sprints.rs
@@ -89,7 +89,7 @@ impl<'a> SprintsIter<'a> {
     }
 
     fn more(&self) -> bool {
-        self.results.is_last
+        !self.results.is_last
     }
 }
 


### PR DESCRIPTION
In Boards a an Sprints iterators the `more()` was returning an inverted value