### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goji"
-version = "0.2.4"
+version = "0.3.0"
 authors = ["softprops <d.tangren@gmail.com>"]
 description = "Rust interface for Jira"
 documentation = "http://softprops.github.io/goji"
@@ -16,12 +16,13 @@ travis-ci = { repository = "softprops/goji" }
 maintenance = { status = "actively-developed" }
 
 [dev-dependencies]
-env_logger = "0.4"
+env_logger = "0.7"
 
 [dependencies]
-log = "0.4.5"
-reqwest = "0.9.2"
+log = "0.4"
+reqwest = "0.10"
+futures = "0.3"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-url = "1.6.1"
+url = "2.1"

--- a/examples/transitions.rs
+++ b/examples/transitions.rs
@@ -1,6 +1,7 @@
 extern crate env_logger;
 extern crate goji;
 
+use futures::executor::block_on;
 use goji::{Credentials, Jira, TransitionTriggerOptions};
 use std::env;
 
@@ -14,15 +15,13 @@ fn main() {
     ) {
         let jira = Jira::new(host, Credentials::Basic(user, pass)).unwrap();
 
-        println!("{:#?}", jira.issues().get(key.clone()));
+        println!("{:#?}", block_on(jira.issues().get(key.clone())));
         let transitions = jira.transitions(key);
-        for option in transitions.list() {
+        for option in block_on(transitions.list()) {
             println!("{:#?}", option);
         }
         if let Ok(transition_id) = env::var("JIRA_TRANSITION_ID") {
-            transitions
-                .trigger(TransitionTriggerOptions::new(transition_id))
-                .unwrap()
+            block_on(transitions.trigger(TransitionTriggerOptions::new(transition_id))).unwrap()
         }
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -63,20 +63,6 @@ impl ::std::fmt::Display for Error {
 }
 
 impl ::std::error::Error for Error {
-    fn description(&self) -> &str {
-        use crate::Error::*;
-
-        match *self {
-            Http(ref e) => e.description(),
-            IO(ref e) => e.description(),
-            Serde(ref e) => e.description(),
-            Fault { .. } => "Jira client error",
-            Unauthorized => "Unauthorized",
-            MethodNotAllowed => "MethodNotAllowed",
-            NotFound => "NotFound",
-        }
-    }
-
     fn cause(&self) -> Option<&dyn (::std::error::Error)> {
         use crate::Error::*;
 

--- a/src/resolution.rs
+++ b/src/resolution.rs
@@ -27,10 +27,12 @@ impl Resolution {
         Resolution { jira: jira.clone() }
     }
 
-    pub fn get<I>(&self, id: I) -> Result<Resolved>
+    pub async fn get<I>(&self, id: I) -> Result<Resolved>
     where
         I: Into<String>,
     {
-        self.jira.get("api", &format!("/resolution/{}", id.into()))
+        self.jira
+            .get("api", &format!("/resolution/{}", id.into()))
+            .await
     }
 }

--- a/src/transitions.rs
+++ b/src/transitions.rs
@@ -22,24 +22,26 @@ impl Transitions {
     }
 
     /// return list of transitions options for this issue
-    pub fn list(&self) -> Result<Vec<TransitionOption>> {
+    pub async fn list(&self) -> Result<Vec<TransitionOption>> {
         self.jira
             .get::<TransitionOptions>(
                 "api",
                 &format!("/issue/{}/transitions?expand=transitions.fields", self.key),
             )
+            .await
             .map(|wrapper| wrapper.transitions)
     }
 
     /// trigger a issue transition
     /// to transition with a resolution use TransitionTrigger::builder(id).resolution(name)
-    pub fn trigger(&self, trans: TransitionTriggerOptions) -> Result<()> {
+    pub async fn trigger(&self, trans: TransitionTriggerOptions) -> Result<()> {
         self.jira
             .post::<(), TransitionTriggerOptions>(
                 "api",
                 &format!("/issue/{}/transitions", self.key),
                 trans,
             )
+            .await
             .or_else(|e| match e {
                 Error::Serde(_) => Ok(()),
                 e => Err(e),


### PR DESCRIPTION
Update reqwest to 0.10.x
We can mark some methods as `async` now, so this is kind of API change, thus bumping "minor" version.

Also, the latest Rust version deprecated `description` method on Errors, so removed it.