### PR TITLE
Allow to get /create / release project version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod issues;
 mod rep;
 mod search;
 mod transitions;
+mod versions;
 
 pub use crate::builder::*;
 pub use crate::errors::*;
@@ -34,6 +35,7 @@ pub mod resolution;
 pub use crate::boards::*;
 pub mod sprints;
 pub use crate::sprints::*;
+pub use crate::versions::*;
 
 #[derive(Deserialize, Debug)]
 pub struct EmptyResponse;
@@ -109,14 +111,28 @@ impl Jira {
         Sprints::new(self)
     }
 
+    pub fn versions(&self) -> Versions {
+        Versions::new(self)
+    }
+
     fn post<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
     where
         D: DeserializeOwned,
         S: Serialize,
     {
         let data = serde_json::to_string::<S>(&body)?;
-        debug!("Json request: {}", data);
+        debug!("Json POST request: {}", data);
         self.request::<D>(Method::POST, api_name, endpoint, Some(data.into_bytes()))
+    }
+
+    fn put<D, S>(&self, api_name: &str, endpoint: &str, body: S) -> Result<D>
+    where
+        D: DeserializeOwned,
+        S: Serialize,
+    {
+        let data = serde_json::to_string::<S>(&body)?;
+        debug!("Json PUT request: {}", data);
+        self.request::<D>(Method::PUT, api_name, endpoint, Some(data.into_bytes()))
     }
 
     fn get<D>(&self, api_name: &str, endpoint: &str) -> Result<D>

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -265,6 +265,12 @@ pub struct VersionCreationBody {
     #[serde(rename = "projectId")]
     pub project_id: u64,
 }
+
+#[derive(Serialize, Debug)]
+pub struct VersionMoveAfterBody {
+    pub after: String,
+}
+
 #[derive(Serialize, Debug)]
 pub struct VersionUpdateBody {
     pub released: bool,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -252,9 +252,25 @@ pub struct Version {
     pub archived: bool,
     pub id: String,
     pub name: String,
+    #[serde(rename = "projectId")]
+    pub project_id: u64,
     pub released: bool,
     #[serde(rename = "self")]
     pub self_link: String,
+}
+
+#[derive(Serialize, Debug)]
+pub struct VersionCreationBody {
+    pub name: String,
+    #[serde(rename = "projectId")]
+    pub project_id: u64,
+}
+#[derive(Serialize, Debug)]
+pub struct VersionUpdateBody {
+    pub released: bool,
+    pub archived: bool,
+    #[serde(rename = "moveUnfixedIssuesTo")]
+    pub move_unfixed_issues_to: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -32,7 +32,7 @@ impl Versions {
     ///
     /// See [jira docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-version-id-put)
     /// for more information
-    pub fn release_version(
+    pub fn release(
         &self,
         version: &Version,
         move_unfixed_issues_to: Option<&Version>,

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,4 +1,6 @@
-use crate::{Error, Jira, Result, Version, VersionCreationBody, VersionUpdateBody};
+use crate::{
+    Error, Jira, Result, Version, VersionCreationBody, VersionMoveAfterBody, VersionUpdateBody,
+};
 
 pub struct Versions {
     jira: Jira,
@@ -26,6 +28,20 @@ impl Versions {
         let name = name.into();
         self.jira
             .post("api", "/version", VersionCreationBody { project_id, name })
+    }
+
+    /// Move a version after another version
+    ///
+    /// See [jira docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-version-id-move-post)
+    /// for more information
+    pub fn move_after<T: Into<String>>(&self, version: &Version, after: T) -> Result<Version> {
+        self.jira.post(
+            "api",
+            &format!("/version/{}/move", version.id),
+            VersionMoveAfterBody {
+                after: after.into(),
+            },
+        )
     }
 
     /// Release a new version: modify the version by turning the released boolean to true

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,0 +1,57 @@
+use crate::{Error, Jira, Result, Version, VersionCreationBody, VersionUpdateBody};
+
+pub struct Versions {
+    jira: Jira,
+}
+
+impl Versions {
+    pub fn new(jira: &Jira) -> Self {
+        Self { jira: jira.clone() }
+    }
+
+    /// Fetch all versions associated to the given project
+    ///
+    /// See [jira docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-project-projectIdOrKey-versions-get)
+    /// for more information
+    pub fn project_versions(&self, project_id_or_key: &str) -> Result<Vec<Version>> {
+        self.jira
+            .get("api", &format!("/project/{}/versions", project_id_or_key))
+    }
+
+    /// Create a new version
+    ///
+    /// See [jira docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-version-post)
+    /// for more information
+    pub fn create<T: Into<String>>(&self, project_id: u64, name: T) -> Result<Version> {
+        let name = name.into();
+        self.jira
+            .post("api", "/version", VersionCreationBody { project_id, name })
+    }
+
+    /// Release a new version: modify the version by turning the released boolean to true
+    ///
+    /// See [jira docs](https://developer.atlassian.com/cloud/jira/platform/rest/v2/#api-rest-api-2-version-id-put)
+    /// for more information
+    pub fn release_version(
+        &self,
+        version: &Version,
+        move_unfixed_issues_to: Option<&Version>,
+    ) -> Result<()> {
+        if version.released {
+            // already released
+            Ok(())
+        } else {
+            self.jira
+                .put::<Version, _>(
+                    "api",
+                    &format!("/version/{}", version.id),
+                    VersionUpdateBody {
+                        released: true,
+                        archived: false,
+                        move_unfixed_issues_to: move_unfixed_issues_to.map(|v| v.self_link.clone()),
+                    },
+                )
+                .map(|_v| ())
+        }
+    }
+}


### PR DESCRIPTION
Hi, here is some code to manipulate project version:
- get all versions of a project
- create new version 
- release a specific version.

This is a very basic implementation that suits my usage...